### PR TITLE
avoid-method-missing-jkakar

### DIFF
--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -2,13 +2,9 @@ class ContextTest < Minitest::Test
   # Context.<name> raises a NoMethodError if an unknown configuration value is
   # requested.
   def test_index_unknown_value
-    context = ConfigVar::Context.new
-    error = assert_raises NoMethodError do
-      context.unknown
+    assert_raises NoMethodError do
+      ConfigVar::Context.new.unknown
     end
-    assert_match(
-      /undefined method `unknown' for #<ConfigVar::Context:0x[0-9a-f]*>/,
-      error.message)
   end
 
   # Context.reload loads required string values.


### PR DESCRIPTION
Define instance methods instead of relying on `method_missing` to see
if we get any performance boost.