### PR TITLE
Add 'enabled' to list of accepted bool truthy values

### DIFF
--- a/lib/configvar/context.rb
+++ b/lib/configvar/context.rb
@@ -123,7 +123,7 @@ module ConfigVar
     # Convert a string to boolean.  An ArgumentError is raised if the string
     # is not a valid boolean.
     def parse_bool(name, value)
-      if ['1', 'true'].include?(value.downcase)
+      if ['1', 'true', 'enabled'].include?(value.downcase)
         true
       elsif ['0', 'false'].include?(value.downcase)
         false

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -66,12 +66,14 @@ class ContextTest < Minitest::Test
     context = ConfigVar::Context.new
     context.required_bool :value_1
     context.required_bool :value_true
+    context.required_bool :value_enabled
     context.required_bool :value_0
     context.required_bool :value_false
-    context.reload('VALUE_1' => '1', 'VALUE_TRUE' => 'True',
+    context.reload('VALUE_1' => '1', 'VALUE_TRUE' => 'True', 'VALUE_ENABLED' => 'enabled',
                    'VALUE_0' => '0', 'VALUE_FALSE' => 'False')
     assert_equal(true, context.value_1)
     assert_equal(true, context.value_true)
+    assert_equal(true, context.value_enabled)
     assert_equal(false, context.value_0)
     assert_equal(false, context.value_false)
   end
@@ -160,12 +162,14 @@ class ContextTest < Minitest::Test
     context = ConfigVar::Context.new
     context.optional_bool :value_1, false
     context.optional_bool :value_true, false
+    context.optional_bool :value_enabled, false
     context.optional_bool :value_0, true
     context.optional_bool :value_false, true
-    context.reload('VALUE_1' => '1', 'VALUE_TRUE' => 'True',
+    context.reload('VALUE_1' => '1', 'VALUE_TRUE' => 'True', 'VALUE_ENABLED' => 'enabled',
                    'VALUE_0' => '0', 'VALUE_FALSE' => 'False')
     assert_equal(true, context.value_1)
     assert_equal(true, context.value_true)
+    assert_equal(true, context.value_enabled)
     assert_equal(false, context.value_0)
     assert_equal(false, context.value_false)
   end


### PR DESCRIPTION
The Heroku ruby-buildpack sets RAILS_LOG_TO_STDOUT and RAILS_SERVE_STATIC_FILES to 'enabled' if they are not present for apps using Rails 4.2 and upwards. This change adds 'enabled' to the list of accepted bool truthy values.
